### PR TITLE
Add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ calculation = 100-50
 - `operation_array` = an array of all the operations
 - `calculation` = the calculation to be used
 
+## Tests
+
+Make sure you have [`bats`](https://github.com/bats-core/bats-core) installed from system repo or otherwise. Then run:
+
+```sh
+tests/run.sh
+# or
+path/to/bats --tap tests
+```
+
 ## TODO
 
 - ~~Better formatted ouput (perhaps `1,000,000` instead of `1000000` for example)~~

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -1,0 +1,3 @@
+REPO_ROOT_PATH="$PWD"
+BINARY_FILE="$PWD/bcalc"
+

--- a/tests/pemdas.bats
+++ b/tests/pemdas.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load common
+
+@test "Single brackets test" {
+	result="$($BINARY_FILE '(2+2)')"
+	[ "$result" -eq 4 ]
+}
+
+@test "Single brackets with basic math test" {
+	result="$($BINARY_FILE '(5+5)/2')"
+	[ "$result" -eq 5 ]
+}
+
+@test "Exponent in bracket with math test" {
+	result="$($BINARY_FILE '(2^2)*2')"
+	[ "$result" -eq 8 ]
+}
+
+@test "2 levels of brackets test" {
+	result="$($BINARY_FILE '((2+2)+2)')"
+	[ "$result" -eq 6 ]
+}
+
+@test "3 levels of brackets test" {
+	result="$($BINARY_FILE '(((2+2)+2)+2)')"
+	[ "$result" -eq 8 ]
+}
+
+@test "Multiple digits without bracket first test" {
+	result="$($BINARY_FILE '1+2*3')"
+	[ "$result" -eq 7 ]
+}
+
+@test "Multiple digits without bracket second test" {
+	result="$($BINARY_FILE '6-1*0+3/3')"
+	[ "$result" -eq 7 ]
+}
+
+@test "Multiple digits with bracket and operations test" {
+	result="$($BINARY_FILE '500-(4*2^2+12)')"
+	[ "$result" -eq 472 ]
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+REPO_ROOT="$(dirname $(dirname $(realpath $0)))"
+bats --tap "$REPO_ROOT/tests"

--- a/tests/simple.bats
+++ b/tests/simple.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load common
+
+@test "Addition test" {
+	result="$($BINARY_FILE 2+2)"
+	[ "$result" -eq 4 ]
+}
+
+@test "Subtraction test" {
+	result="$($BINARY_FILE 4-2)"
+	[ "$result" -eq 2 ]
+}
+
+@test "Multiplication test" {
+	result="$($BINARY_FILE 4*2)"
+	[ "$result" -eq 8 ]
+}
+
+@test "Division test" {
+	result="$($BINARY_FILE 4/2)"
+	[ "$result" -eq 2 ]
+}
+
+@test "Division with remainder test" {
+	result="$($BINARY_FILE 5%2)"
+	[ "$result" -eq 1 ]
+}
+
+@test "Exponent test" {
+	result="$($BINARY_FILE 3^2)"
+	[ "$result" -eq 9 ]
+}
+
+@test "Decimal not supported error test" {
+	run "$BINARY_FILE" 1.1+2.2
+	[ $status -eq 1 ]
+	[ "${lines[0]}" == "Only digits, parenthesis, '^', '*', '%', '/', '+', and '-', are supported." ]
+	[ "${lines[1]}" == "'.' is currently unsupported." ]
+}


### PR DESCRIPTION
Add tests based on bats, a TAP-compliant testing framework for bash. Requires: `bats` package (available on Debian/Arch repos) and then `tests/run.sh` to run the tests (instructions on readme as well).

Should fix #10 

Example output:

```
1..15
ok 1 Single brackets test
ok 2 Single brackets with basic math test
ok 3 Exponent in bracket with math test
not ok 4 2 levels of brackets test
# (in test file tests/pemdas.bats, line 22)
#   `[ "$result" -eq 6 ]' failed
not ok 5 3 levels of brackets test
# (in test file tests/pemdas.bats, line 27)
#   `[ "$result" -eq 8 ]' failed
ok 6 Multiple digits without bracket first test
ok 7 Multiple digits without bracket second test
ok 8 Multiple digits with bracket and operations test
ok 9 Addition test
ok 10 Subtraction test
ok 11 Multiplication test
ok 12 Division test
ok 13 Division with remainder test
ok 14 Exponent test
ok 15 Decimal not supported error test
```

The 2 failed tests are due to [this](https://github.com/Phate6660/bcalc/issues/6#issuecomment-809547200) which will probably be fixed soon and it will pass.